### PR TITLE
Fix build.py

### DIFF
--- a/src/application/build.py
+++ b/src/application/build.py
@@ -87,6 +87,7 @@ def make_main():
 
     #These are the minimum requirements for the main method to work
     main_str += "def get_metrics(url='', user='', passwrd=''):\n"
+    main_str += "\turl = check_cluster(url, user, passwrd)\n"
     main_str += "\tcluster_values = cb_cluster._get_cluster(url, user, passwrd, [])\n"
     main_str += "\tmetrics = cluster_values['metrics']\n"
     main_str += "\tindex_buckets = cb_bucket._get_index_buckets(url, user, passwrd)\n"

--- a/src/application/main.py
+++ b/src/application/main.py
@@ -13,6 +13,7 @@ PASSWD = ''
 from modules import *
 
 def get_metrics(url='', user='', passwrd=''):
+	url = check_cluster(url, user, passwrd)
 	cluster_values = cb_cluster._get_cluster(url, user, passwrd, [])
 	metrics = cluster_values['metrics']
 	index_buckets = cb_bucket._get_index_buckets(url, user, passwrd)


### PR DESCRIPTION
Added back in a line that was missing in the build script that caused an error when passing in multiple nodes to the bootstrap list to the main.py /metrics endpoint.