### PR TITLE
Fixed Issue where metrics aren't returned when stat ticks are missing

### DIFF
--- a/src/application/modules/cb_analytics.py
+++ b/src/application/modules/cb_analytics.py
@@ -64,19 +64,34 @@ def _get_metrics(user, passwrd, node_list, cluster_name="", result_set=60):
                 node_hostname, node_hostname)
             a_json = rest_request(auth, _cbas_url)
             _node = node
-            for record in a_json['op']['samples']:
-                if record != "timestamp":
-                    for idx, datapoint in enumerate(
-                            a_json['op']['samples'][record]):
-                        if idx in sample_list:
-                            cbas_metrics['metrics'].append(
-                                "{} {{cluster=\"{}\", node=\"{}\", "
-                                "type=\"cbas\"}} {} {}".format(
-                                    record,
-                                    cluster_name,
-                                    node_hostname,
-                                    datapoint,
-                                    a_json['op']['samples']['timestamp'][idx]))
+            samples_count = len(a_json['op']['samples'][record])
+            # if the sample list value is greater than the samples count, just use the last sample
+            if samples_count < sample_list[0]:
+                cbas_metrics['metrics'].append(
+                    "{} {{cluster=\"{}\", node=\"{}\", "
+                    "type=\"cbas\"}} {} {}".format(
+                        record,
+                        cluster_name,
+                        node_hostname,
+                        a_json['op']['samples'][record][samples_count - 1],
+                        a_json['op']['samples']['timestamp'][samples_count - 1]
+                    )
+                )
+            else:
+                for record in a_json['op']['samples']:
+                    if record != "timestamp":
+                        for idx, datapoint in enumerate(a_json['op']['samples'][record]):
+                            if idx in sample_list:
+                                cbas_metrics['metrics'].append(
+                                    "{} {{cluster=\"{}\", node=\"{}\", "
+                                    "type=\"cbas\"}} {} {}".format(
+                                        record,
+                                        cluster_name,
+                                        node_hostname,
+                                        datapoint,
+                                        a_json['op']['samples']['timestamp'][idx]
+                                    )
+                                )
         except Exception as e:
             print("analytics base: " + str(e))
     return cbas_metrics

--- a/src/application/modules/cb_bucket.py
+++ b/src/application/modules/cb_bucket.py
@@ -113,27 +113,50 @@ def _get_metrics(user, passwrd, node_list, cluster_name="", bucket_names=[], res
                         b_json = rest_request(auth, bucket_url)
                         for _record in b_json['op']['samples']:
                             record = value_to_string(_record)
+                            split_record = record.split("/")
+                            samples_count = len(b_json['op']['samples'][_record])
                             if record != "timestamp":
-                                if len(record.split("/")) == 3:
-                                    ddoc_type = record.split("/")[0]
-                                    ddoc_uuid = record.split("/")[1]
-                                    ddoc_stat = record.split("/")[2]
-                                    for idx, dpt in enumerate(b_json['op']['samples'][_record]):
-                                        if idx in sample_list:
-                                            bucket_info['metrics'].append(
-                                                "{} {{cluster=\"{}\", bucket=\"{}\", "
-                                                "node=\"{}\", "
-                                                "type=\"view\" "
-                                                "viewType=\"{}\", "
-                                                "view=\"{}\"}} {} {}".format(
-                                                    ddoc_stat,
-                                                    cluster_name,
-                                                    bucket['name'],
-                                                    node_hostname,
-                                                    ddoc_type,
-                                                    ddoc_uuid,
-                                                    dpt,
-                                                    b_json['op']['samples']['timestamp'][idx]))
+                                if len(split_record) == 3:
+                                    ddoc_type = split_record[0]
+                                    ddoc_uuid = split_record[1]
+                                    ddoc_stat = split_record[2]
+                                    # if the sample list value is greater than the samples count, just use the last sample
+                                    if samples_count < sample_list[0]:
+                                        bucket_info['metrics'].append(
+                                            "{} {{cluster=\"{}\", bucket=\"{}\", "
+                                            "node=\"{}\", "
+                                            "type=\"view\" "
+                                            "viewType=\"{}\", "
+                                            "view=\"{}\"}} {} {}".format(
+                                                ddoc_stat,
+                                                cluster_name,
+                                                bucket['name'],
+                                                node_hostname,
+                                                ddoc_type,
+                                                ddoc_uuid,
+                                                b_json['op']['samples'][_record][samples_count - 1],
+                                                b_json['op']['samples']['timestamp'][samples_count - 1]
+                                            )
+                                        )
+                                    else:
+                                        for idx, dpt in enumerate(b_json['op']['samples'][_record]):
+                                            if idx in sample_list:
+                                                bucket_info['metrics'].append(
+                                                    "{} {{cluster=\"{}\", bucket=\"{}\", "
+                                                    "node=\"{}\", "
+                                                    "type=\"view\" "
+                                                    "viewType=\"{}\", "
+                                                    "view=\"{}\"}} {} {}".format(
+                                                        ddoc_stat,
+                                                        cluster_name,
+                                                        bucket['name'],
+                                                        node_hostname,
+                                                        ddoc_type,
+                                                        ddoc_uuid,
+                                                        dpt,
+                                                        b_json['op']['samples']['timestamp'][idx]
+                                                    )
+                                                )
 
                                 else:
                                     for idx, dpt in enumerate(b_json['op']['samples'][_record]):
@@ -158,13 +181,34 @@ def _get_metrics(user, passwrd, node_list, cluster_name="", bucket_names=[], res
                         b_json = rest_request(auth, bucket_url)
                         for _record in b_json['op']['samples']:
                             record = value_to_string(_record)
+                            split_record = record.split("/")
+                            samples_count = len(b_json['op']['samples'][_record])
                             if record != "timestamp":
-                                if len(record.split("/")) == 3:
-                                    ddoc_type = record.split("/")[0]
-                                    ddoc_uuid = record.split("/")[1]
-                                    ddoc_stat = record.split("/")[2]
-                                    for idx, dpt in enumerate(b_json['op']['samples'][_record]):
-                                        if idx in sample_list:
+                                if len(split_record) == 3:
+                                    ddoc_type = split_record[0]
+                                    ddoc_uuid = split_record[1]
+                                    ddoc_stat = split_record[2]
+                                    # if the sample list value is greater than the samples count, just use the last sample
+                                    if samples_count < sample_list[0]:
+                                        bucket_info['metrics'].append(
+                                            "{} {{cluster=\"{}\", bucket=\"{}\", "
+                                            "node=\"{}\", "
+                                            "type=\"view\" "
+                                            "viewType=\"{}\", "
+                                            "view=\"{}\"}} {} {}".format(
+                                                ddoc_stat,
+                                                cluster_name,
+                                                bucket,
+                                                node_hostname,
+                                                ddoc_type,
+                                                ddoc_uuid,
+                                                b_json['op']['samples'][_record][samples_count - 1],
+                                                b_json['op']['samples']['timestamp'][samples_count - 1]
+                                            )
+                                        )
+                                    else:
+                                        # if the sample list value is greater than the samples count, just use the last sample
+                                        if samples_count < sample_list[0]:
                                             bucket_info['metrics'].append(
                                                 "{} {{cluster=\"{}\", bucket=\"{}\", "
                                                 "node=\"{}\", "
@@ -177,22 +221,60 @@ def _get_metrics(user, passwrd, node_list, cluster_name="", bucket_names=[], res
                                                     node_hostname,
                                                     ddoc_type,
                                                     ddoc_uuid,
-                                                    dpt,
-                                                    b_json['op']['samples']['timestamp'][idx]))
+                                                    b_json['op']['samples'][_record][samples_count - 1],
+                                                    b_json['op']['samples']['timestamp'][samples_count - 1]
+                                                )
+                                            )
+                                        else:
+                                            for idx, dpt in enumerate(b_json['op']['samples'][_record]):
+                                                if idx in sample_list:
+                                                    bucket_info['metrics'].append(
+                                                        "{} {{cluster=\"{}\", bucket=\"{}\", "
+                                                        "node=\"{}\", "
+                                                        "type=\"view\" "
+                                                        "viewType=\"{}\", "
+                                                        "view=\"{}\"}} {} {}".format(
+                                                            ddoc_stat,
+                                                            cluster_name,
+                                                            bucket,
+                                                            node_hostname,
+                                                            ddoc_type,
+                                                            ddoc_uuid,
+                                                            dpt,
+                                                            b_json['op']['samples']['timestamp'][idx]
+                                                        )
+                                                    )
 
                                 else:
-                                    for idx, dpt in enumerate(b_json['op']['samples'][_record]):
-                                        if idx in sample_list:
-                                            bucket_info['metrics'].append(
-                                                "{} {{cluster=\"{}\", bucket=\"{}\", "
-                                                "node=\"{}\", "
-                                                "type=\"bucket\"}} {} {}".format(
-                                                    record,
-                                                    cluster_name,
-                                                    bucket,
-                                                    node_hostname,
-                                                    dpt,
-                                                    b_json['op']['samples']['timestamp'][idx]))
+                                    # if the sample list value is greater than the samples count, just use the last sample
+                                    if samples_count < sample_list[0]:
+                                        bucket_info['metrics'].append(
+                                            "{} {{cluster=\"{}\", bucket=\"{}\", "
+                                            "node=\"{}\", "
+                                            "type=\"bucket\"}} {} {}".format(
+                                                record,
+                                                cluster_name,
+                                                bucket,
+                                                node_hostname,
+                                                b_json['op']['samples'][_record][samples_count - 1],
+                                                b_json['op']['samples']['timestamp'][samples_count - 1]
+                                            )
+                                        )
+                                    else:
+                                        for idx, dpt in enumerate(b_json['op']['samples'][_record]):
+                                            if idx in sample_list:
+                                                bucket_info['metrics'].append(
+                                                    "{} {{cluster=\"{}\", bucket=\"{}\", "
+                                                    "node=\"{}\", "
+                                                    "type=\"bucket\"}} {} {}".format(
+                                                        record,
+                                                        cluster_name,
+                                                        bucket,
+                                                        node_hostname,
+                                                        dpt,
+                                                        b_json['op']['samples']['timestamp'][idx]
+                                                    )
+                                                )
             except Exception as e:
                 print(e)
     except Exception as e:

--- a/src/application/modules/cb_eventing.py
+++ b/src/application/modules/cb_eventing.py
@@ -65,24 +65,42 @@ def _get_metrics(user, passwrd, node_list, cluster_name="", result_set=60):
                 name = ""
                 metric_type = ""
                 node_hostname = node.split(":")[0]
+                samples_count = len(e_json['op']['samples'][record])
                 try:
                     split_record = record.split("/")
                     if len(split_record) == 3:
                         name = (split_record[1]).replace("+", "_")
                         metric_type = (split_record[2]).replace("+", "_")
                         if isinstance(e_json['op']['samples'][record], type([])):
-                            for idx, datapoint in enumerate(e_json['op']['samples'][record]):
-                                if idx in sample_list:
-                                    eventing_metrics['metrics'].append(
-                                        "{} {{cluster=\"{}\", node=\"{}\", "
-                                        "function=\"{}\", "
-                                        "type=\"eventing_stat\"}} {} {}".format(
-                                            metric_type,
-                                            cluster_name,
-                                            node_hostname,
-                                            name,
-                                            datapoint,
-                                            e_json['op']['samples']['timestamp'][idx]))
+                            # if the sample list value is greater than the samples count, just use the last sample
+                            if samples_count < sample_list[0]:
+                                eventing_metrics['metrics'].append(
+                                    "{} {{cluster=\"{}\", node=\"{}\", "
+                                    "function=\"{}\", "
+                                    "type=\"eventing_stat\"}} {} {}".format(
+                                        metric_type,
+                                        cluster_name,
+                                        node_hostname,
+                                        name,
+                                        e_json['op']['samples'][record][samples_count - 1],
+                                        e_json['op']['samples']['timestamp'][samples_count - 1]
+                                    )
+                                )
+                            else:
+                                for idx, datapoint in enumerate(e_json['op']['samples'][record]):
+                                    if idx in sample_list:
+                                        eventing_metrics['metrics'].append(
+                                            "{} {{cluster=\"{}\", node=\"{}\", "
+                                            "function=\"{}\", "
+                                            "type=\"eventing_stat\"}} {} {}".format(
+                                                metric_type,
+                                                cluster_name,
+                                                node_hostname,
+                                                name,
+                                                datapoint,
+                                                e_json['op']['samples']['timestamp'][idx]
+                                            )
+                                        )
                         else:
                             eventing_metrics['metrics'].append(
                                 "{} {{cluster=\"{}\", node=\"{}\", "
@@ -92,21 +110,38 @@ def _get_metrics(user, passwrd, node_list, cluster_name="", result_set=60):
                                     cluster_name,
                                     node_hostname,
                                     name,
-                                    e_json['op']['samples'][record]))
+                                    e_json['op']['samples'][record]
+                                )
+                            )
                     elif len(split_record) == 2:
                         metric_type = (split_record[1]).replace("+", "_")
                         if isinstance(e_json['op']['samples'][record], type([])):
-                            for idx, datapoint in enumerate(
-                                    e_json['op']['samples'][record]):
-                                if idx in sample_list:
-                                    eventing_metrics['metrics'].append(
-                                        "{} {{cluster=\"{}\", node=\"{}\", "
-                                        "type=\"eventing_stat\"}} {} {}".format(
-                                            metric_type,
-                                            cluster_name,
-                                            node_hostname,
-                                            datapoint,
-                                            e_json['op']['samples']['timestamp'][idx]))
+                            # if the sample list value is greater than the samples count, just use the last sample
+                            if samples_count < sample_list[0]:
+                                eventing_metrics['metrics'].append(
+                                    "{} {{cluster=\"{}\", node=\"{}\", "
+                                    "type=\"eventing_stat\"}} {} {}".format(
+                                        metric_type,
+                                        cluster_name,
+                                        node_hostname,
+                                        e_json['op']['samples']['timestamp'][samples_count - 1],
+                                        e_json['op']['samples']['timestamp'][samples_count - 1]
+                                    )
+                                )
+                            else:
+                                for idx, datapoint in enumerate(
+                                        e_json['op']['samples'][record]):
+                                    if idx in sample_list:
+                                        eventing_metrics['metrics'].append(
+                                            "{} {{cluster=\"{}\", node=\"{}\", "
+                                            "type=\"eventing_stat\"}} {} {}".format(
+                                                metric_type,
+                                                cluster_name,
+                                                node_hostname,
+                                                datapoint,
+                                                e_json['op']['samples']['timestamp'][idx]
+                                            )
+                                        )
                         else:
                             eventing_metrics['metrics'].append(
                                 "{} {{cluster=\"{}\", node=\"{}\", "
@@ -114,7 +149,9 @@ def _get_metrics(user, passwrd, node_list, cluster_name="", result_set=60):
                                     metric_type,
                                     cluster_name,
                                     node_hostname,
-                                    datapoint))
+                                    datapoint
+                                )
+                            )
                     else:
                         next
                 except Exception as e:

--- a/src/application/modules/cb_fts.py
+++ b/src/application/modules/cb_fts.py
@@ -90,23 +90,41 @@ def _get_metrics(user, passwrd, node_list, bucket_list, cluster_name="", result_
                     metric_type = ""
                     try:
                         split_record = record.split("/")
+                        samples_count = len(f_json['op']['samples'][record])
                         if len(split_record) == 3:
                             name = (split_record[1]).replace("+", "_")
                             metric_type = (split_record[2]).replace("+", "_")
                             if isinstance(f_json['op']['samples'][record], type([])):
-                                for idx, datapoint in enumerate(
-                                        f_json['op']['samples'][record]):
-                                    if idx in sample_list:
-                                        fts_metrics['metrics'].append(
-                                            "{} {{cluster=\"{}\", node=\"{}\", "
-                                            "index=\"{}\", "
-                                            "type=\"fts_stat\"}} {} {}".format(
-                                                metric_type,
-                                                cluster_name,
-                                                node_hostname,
-                                                name,
-                                                datapoint,
-                                                f_json['op']['samples']['timestamp'][idx]))
+                                # if the sample list value is greater than the samples count, just use the last sample
+                                if samples_count < sample_list[0]:
+                                    fts_metrics['metrics'].append(
+                                        "{} {{cluster=\"{}\", node=\"{}\", "
+                                        "index=\"{}\", "
+                                        "type=\"fts_stat\"}} {} {}".format(
+                                            metric_type,
+                                            cluster_name,
+                                            node_hostname,
+                                            name,
+                                            f_json['op']['samples'][record][samples_count - 1],
+                                            f_json['op']['samples']['timestamp'][samples_count - 1]
+                                        )
+                                    )
+                                else:
+                                    for idx, datapoint in enumerate(
+                                            f_json['op']['samples'][record]):
+                                        if idx in sample_list:
+                                            fts_metrics['metrics'].append(
+                                                "{} {{cluster=\"{}\", node=\"{}\", "
+                                                "index=\"{}\", "
+                                                "type=\"fts_stat\"}} {} {}".format(
+                                                    metric_type,
+                                                    cluster_name,
+                                                    node_hostname,
+                                                    name,
+                                                    datapoint,
+                                                    f_json['op']['samples']['timestamp'][idx]
+                                                )
+                                            )
                             else:
                                 fts_metrics['metrics'].append(
                                     "{} {{cluster=\"{}\", node=\"{}\", "
@@ -116,20 +134,37 @@ def _get_metrics(user, passwrd, node_list, bucket_list, cluster_name="", result_
                                         cluster_name,
                                         node_hostname,
                                         name,
-                                        f_json['op']['samples'][record]))
+                                        f_json['op']['samples'][record]
+                                    )
+                                )
                         elif len(split_record) == 2:
                             metric_type = (split_record[1]).replace("+", "_")
                             if isinstance(f_json['op']['samples'][record], type([])):
-                                for idx, datapoint in enumerate(f_json['op']['samples'][record]):
-                                    if idx in sample_list:
-                                        fts_metrics['metrics'].append(
-                                            "{} {{cluster=\"{}\", node=\"{}\", "
-                                            "type=\"fts_stat\"}} {} {}".format(
-                                                metric_type,
-                                                cluster_name,
-                                                node_hostname,
-                                                datapoint,
-                                                f_json['op']['samples']['timestamp'][idx]))
+                                # if the sample list value is greater than the samples count, just use the last sample
+                                if samples_count < sample_list[0]:
+                                    fts_metrics['metrics'].append(
+                                        "{} {{cluster=\"{}\", node=\"{}\", "
+                                        "type=\"fts_stat\"}} {} {}".format(
+                                            metric_type,
+                                            cluster_name,
+                                            node_hostname,
+                                            f_json['op']['samples'][record][samples_count - 1],
+                                            f_json['op']['samples']['timestamp'][samples_count - 1]
+                                        )
+                                    )
+                                else:
+                                    for idx, datapoint in enumerate(f_json['op']['samples'][record]):
+                                        if idx in sample_list:
+                                            fts_metrics['metrics'].append(
+                                                "{} {{cluster=\"{}\", node=\"{}\", "
+                                                "type=\"fts_stat\"}} {} {}".format(
+                                                    metric_type,
+                                                    cluster_name,
+                                                    node_hostname,
+                                                    datapoint,
+                                                    f_json['op']['samples']['timestamp'][idx]
+                                                )
+                                            )
 
                             else:
                                 fts_metrics['metrics'].append(
@@ -138,7 +173,9 @@ def _get_metrics(user, passwrd, node_list, bucket_list, cluster_name="", result_
                                         metric_type,
                                         cluster_name,
                                         node_hostname,
-                                        f_json['op']['samples'][record]))
+                                        f_json['op']['samples'][record]
+                                    )
+                                )
                         else:
                             pass
 

--- a/src/application/modules/cb_query.py
+++ b/src/application/modules/cb_query.py
@@ -76,17 +76,33 @@ def _get_metrics(user, passwrd, node_list, cluster_name="", slow_queries=True, r
                 node_hostname, node_hostname)
             q_json = rest_request(auth, _query_url)
             for record in q_json['op']['samples']:
+                samples_count = len(q_json['op']['samples'][record])
                 if record != "timestamp":
-                    for idx, datapoint in enumerate(q_json['op']['samples'][record]):
-                        if idx in sample_list:
-                            query_info['metrics'].append(
-                                "{} {{cluster=\"{}\", node=\"{}\", "
-                                "type=\"query\"}} {} {}".format(
-                                    record,
-                                    cluster_name,
-                                    node_hostname,
-                                    datapoint,
-                                    q_json['op']['samples']['timestamp'][idx]))
+                    # if the sample list value is greater than the samples count, just use the last sample
+                    if samples_count < sample_list[0]:
+                        query_info['metrics'].append(
+                            "{} {{cluster=\"{}\", node=\"{}\", "
+                            "type=\"query\"}} {} {}".format(
+                                record,
+                                cluster_name,
+                                node_hostname,
+                                q_json['op']['samples'][record][samples_count - 1],
+                                q_json['op']['samples']['timestamp'][samples_count - 1]
+                            )
+                        )
+                    else:
+                        for idx, datapoint in enumerate(q_json['op']['samples'][record]):
+                            if idx in sample_list:
+                                query_info['metrics'].append(
+                                    "{} {{cluster=\"{}\", node=\"{}\", "
+                                    "type=\"query\"}} {} {}".format(
+                                        record,
+                                        cluster_name,
+                                        node_hostname,
+                                        datapoint,
+                                        q_json['op']['samples']['timestamp'][idx]
+                                    )
+                                )
 
         except Exception as e:
             print("query base: " + str(e))

--- a/src/application/modules/cb_system.py
+++ b/src/application/modules/cb_system.py
@@ -93,16 +93,31 @@ def _get_metrics(user, passwrd, node_list, cluster_name="", result_set=60):
             q_json = rest_request(auth, _query_url)
             for record in q_json['op']['samples']:
                 if record != "timestamp":
-                    for idx, datapoint in enumerate(q_json['op']['samples'][record]):
-                        if idx in sample_list:
-                            system_info['metrics'].append(
-                                "{} {{cluster=\"{}\", node=\"{}\", "
-                                "type=\"system\"}} {} {}".format(
-                                    record,
-                                    cluster_name,
-                                    node_hostname,
-                                    datapoint,
-                                    q_json['op']['samples']['timestamp'][idx]))
+                    # if the sample list value is greater than the samples count, just use the last sample
+                    if samples_count < sample_list[0]:
+                        system_info['metrics'].append(
+                            "{} {{cluster=\"{}\", node=\"{}\", "
+                            "type=\"system\"}} {} {}".format(
+                                record,
+                                cluster_name,
+                                node_hostname,
+                                q_json['op']['samples'][record][samples_count - 1],
+                                q_json['op']['samples']['timestamp'][samples_count - 1]
+                            )
+                        )
+                    else:
+                        for idx, datapoint in enumerate(q_json['op']['samples'][record]):
+                            if idx in sample_list:
+                                system_info['metrics'].append(
+                                    "{} {{cluster=\"{}\", node=\"{}\", "
+                                    "type=\"system\"}} {} {}".format(
+                                        record,
+                                        cluster_name,
+                                        node_hostname,
+                                        datapoint,
+                                        q_json['op']['samples']['timestamp'][idx]
+                                    )
+                                )
 
         except Exception as e:
             print("system base: " + str(e))

--- a/src/application/modules/cb_xdcr.py
+++ b/src/application/modules/cb_xdcr.py
@@ -259,35 +259,66 @@ def _get_metrics(user, passwrd, nodes, buckets, cluster_name="", result_set=60):
                 n_json = rest_request(auth, _node_url)
                 for entry in n_json['op']['samples']:
                     key_split = entry.split("/")
+                    samples_count = len(n_json['op']['samples'][entry])
                     if "timestamp" not in key_split:
                         if len(key_split) == 5:
                             if key_split[4] != "":
                                 if isinstance(n_json['op']['samples'][entry], type([])):
-                                    for idx, datapoint in enumerate(n_json['op']['samples'][entry]):
-                                        if idx in sample_list:
-                                            xdcr_metrics['metrics'].append(
-                                                "{} {{cluster=\"{}\", remote_cluster_id=\"{}\", "
-                                                "replication_id=\"{}\", "
-                                                "replication=\"{}\", "
-                                                "level=\"node\", "
-                                                "source_bucket=\"{}\", "
-                                                "dest_cluster_name=\"{}\", "
-                                                "dest_cluster_address=\"{}\", "
-                                                "dest_bucket=\"{}\", "
-                                                "type=\"xdcr\", "
-                                                "node=\"{}\"}} {} {}".format(
-                                                    snake_caseify(key_split[4]),
-                                                    cluster_name,
-                                                    key_split[1],
-                                                    key_split[1] + "/" + key_split[2] + "/" + key_split[3],
-                                                    key_split[2] + " -> " + cluster_definition[key_split[1]]['name'] + " (" + key_split[3] + ")",
-                                                    key_split[2],
-                                                    cluster_definition[key_split[1]]['name'],
-                                                    cluster_definition[key_split[1]]['hostname'],
-                                                    key_split[3],
-                                                    node_hostname,
-                                                    datapoint,
-                                                    n_json['op']['samples']['timestamp'][idx]))
+                                    # if the sample list value is greater than the samples count, just use the last sample
+                                    if samples_count < sample_list[0]:
+                                        xdcr_metrics['metrics'].append(
+                                            "{} {{cluster=\"{}\", remote_cluster_id=\"{}\", "
+                                            "replication_id=\"{}\", "
+                                            "replication=\"{}\", "
+                                            "level=\"node\", "
+                                            "source_bucket=\"{}\", "
+                                            "dest_cluster_name=\"{}\", "
+                                            "dest_cluster_address=\"{}\", "
+                                            "dest_bucket=\"{}\", "
+                                            "type=\"xdcr\", "
+                                            "node=\"{}\"}} {} {}".format(
+                                                snake_caseify(key_split[4]),
+                                                cluster_name,
+                                                key_split[1],
+                                                key_split[1] + "/" + key_split[2] + "/" + key_split[3],
+                                                key_split[2] + " -> " + cluster_definition[key_split[1]]['name'] + " (" + key_split[3] + ")",
+                                                key_split[2],
+                                                cluster_definition[key_split[1]]['name'],
+                                                cluster_definition[key_split[1]]['hostname'],
+                                                key_split[3],
+                                                node_hostname,
+                                                n_json['op']['samples'][entry][samples_count - 1],
+                                                n_json['op']['samples']['timestamp'][samples_count - 1]
+                                            )
+                                        )
+                                    else:
+                                        for idx, datapoint in enumerate(n_json['op']['samples'][entry]):
+                                            if idx in sample_list:
+                                                xdcr_metrics['metrics'].append(
+                                                    "{} {{cluster=\"{}\", remote_cluster_id=\"{}\", "
+                                                    "replication_id=\"{}\", "
+                                                    "replication=\"{}\", "
+                                                    "level=\"node\", "
+                                                    "source_bucket=\"{}\", "
+                                                    "dest_cluster_name=\"{}\", "
+                                                    "dest_cluster_address=\"{}\", "
+                                                    "dest_bucket=\"{}\", "
+                                                    "type=\"xdcr\", "
+                                                    "node=\"{}\"}} {} {}".format(
+                                                        snake_caseify(key_split[4]),
+                                                        cluster_name,
+                                                        key_split[1],
+                                                        key_split[1] + "/" + key_split[2] + "/" + key_split[3],
+                                                        key_split[2] + " -> " + cluster_definition[key_split[1]]['name'] + " (" + key_split[3] + ")",
+                                                        key_split[2],
+                                                        cluster_definition[key_split[1]]['name'],
+                                                        cluster_definition[key_split[1]]['hostname'],
+                                                        key_split[3],
+                                                        node_hostname,
+                                                        datapoint,
+                                                        n_json['op']['samples']['timestamp'][idx]
+                                                    )
+                                                )
                         elif len(key_split) == 1:
                             for idx, datapoint in enumerate(
                                     n_json['op']['samples'][entry]):


### PR DESCRIPTION
in certain scenarios in under provisioned or resource starved clusters, the number of samples returned by ns_server while expected to be 60, can be less than 60 if  there were missing stat ticks, this accounts for that scenario when `CB_RESULTSET = 1` and the number of samples returned is less than 60.  This allows for at least 1 metric to be returned

Resolves #103