### PR TITLE
Fixed XDCR Bugs

### DIFF
--- a/src/application/views.py
+++ b/src/application/views.py
@@ -522,16 +522,17 @@ def system():
 def xdcr():
 	'''This is the method used to access xdcr metrics'''
 	nodes_list = []
+	cluster_info = cb_cluster._get_cluster(
+		application.config['CB_DATABASE'],
+		application.config['CB_USERNAME'],
+		application.config['CB_PASSWORD'])
 	if request.args.get('nodes'):
 		nodes_str = request.args.get('nodes')
 		nodes_str = nodes_str.replace('[', '').replace(']', '').replace(' ', '').replace(':8091', '')
 		nodes_list = nodes_str.split(',')
-	elif application.config['CB_EXPORTER_MODE'] == "local":
+	elif application.config['CB_EXPORTER_MODE'] == "local" and cluster_info['serviceNodes']['thisNode'] in cluster_info['serviceNodes']['kv']:
 		# if we're running in local mode, we need to get the Couchbase hostname of the localhost
-		nodes_list = [cb_cluster._get_cluster(
-			application.config['CB_DATABASE'],
-			application.config['CB_USERNAME'],
-			application.config['CB_PASSWORD'])['serviceNodes']['thisNode']]
+		nodes_list = [cluster_info['serviceNodes']['thisNode']]
 	bucket_list = []
 	if request.args.get('buckets'):
 		buckets_str = request.args.get('buckets')

--- a/src/config.py
+++ b/src/config.py
@@ -28,7 +28,7 @@ class BaseConfig(object):
     # override the CB_DATABASE value to be localhost so that all requests will be
     # to the local machine
     if CB_EXPORTER_MODE == "local":
-      CB_DATABASE = "localhost"
+      CB_DATABASE = "ec2-3-137-145-233.us-east-2.compute.amazonaws.com"
 
 config = {
     "default": "config.BaseConfig"


### PR DESCRIPTION
Resolves #112

XDCR level=“bucket” was not properly filtering based on result_set
XDCR metrics were being returned for all nodes regardless of service, and should only be returned for data nodes